### PR TITLE
fix(generator): resolve proto package name generation issues

### DIFF
--- a/httpinterface/templates/header-template.go.tmpl
+++ b/httpinterface/templates/header-template.go.tmpl
@@ -136,5 +136,5 @@ func (g RouteGroup) GetRoutes() []string {
 
 // ServeHTTP implements the http.Handler interface
 func (g *RouteGroup) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	g.mux.ServeHTTP(w, req)
+	g.mux.ServeHTTP(w, r)
 }


### PR DESCRIPTION
- Fix package name generation for complex proto packages
- Add comprehensive test suite for package name handling
- Handle edge cases and enterprise patterns
- Maintain backward compatibility
- Improve go_package option parsing

The previous implementation incorrectly handled proto packages with 
multiple segments, producing malformed package names. This fix ensures
proper package name generation, especially for cases like: `api.core.oauth.v1` -> `oauthv1`
  
