### PR TITLE
feat: add support for `editions` in HTTP interface generator and parser

### DIFF
--- a/examples/product/buf.gen.yaml
+++ b/examples/product/buf.gen.yaml
@@ -10,7 +10,9 @@ plugins:
     opt: paths=source_relative
   - local: protoc-gen-go-http-server-interface
     out: pb
-    opt: paths=source_relative
+    opt: 
+      - paths=source_relative
+      - editions=true
   # - remote: buf.build/grpc-ecosystem/openapiv2
   #   out: docs
 inputs:

--- a/httpinterface/options.go
+++ b/httpinterface/options.go
@@ -11,7 +11,8 @@ type Options struct {
 	PathsSourceRelative bool
 	// OutputPrefix is an optional prefix for output files
 	OutputPrefix string
-	// Other options can be added here as needed
+	// SupportsEditions determines if the plugin should advertise editions support
+	SupportsEditions bool
 }
 
 // ParseOptions parses the parameter string from protoc into an Options struct
@@ -41,6 +42,12 @@ func ParseOptions(parameter string) (*Options, error) {
 			}
 		case "output_prefix":
 			options.OutputPrefix = value
+		case "editions":
+			if value == "false" {
+				options.SupportsEditions = false
+			} else if value != "true" {
+				return nil, fmt.Errorf("invalid editions option: %s (must be 'true' or 'false')", value)
+			}
 		default:
 			// You might want to either error on unknown options, or just ignore them
 			// For now, we'll log a warning and continue

--- a/httpinterface/parser/editions_parser.go
+++ b/httpinterface/parser/editions_parser.go
@@ -1,0 +1,98 @@
+package parser
+
+import (
+	"regexp"
+
+	"github.com/golang/protobuf/protoc-gen-go/descriptor"
+	options "google.golang.org/genproto/googleapis/api/annotations"
+	"google.golang.org/protobuf/proto"
+)
+
+// EditionsParser implements parsing for editions files
+type EditionsParser struct{}
+
+// NewEditionsParser creates a new parser for editions
+func NewEditionsParser() *EditionsParser {
+	return &EditionsParser{}
+}
+
+// ParseHTTPRules extracts HTTP rules from a method descriptor
+func (p *EditionsParser) ParseHTTPRules(method *descriptor.MethodDescriptorProto) []HTTPRule {
+	rules := []HTTPRule{}
+
+	if method.Options != nil {
+		v := proto.GetExtension(method.Options, options.E_Http)
+		httpRule := v.(*options.HttpRule)
+		if httpRule != nil {
+			// Add the main rule
+			rule := p.parseHTTPRule(httpRule)
+			if rule.Method != "" {
+				rule.PathParams = p.ParsePathParams(rule.Pattern)
+				rules = append(rules, rule)
+			}
+
+			// Add additional bindings
+			for _, binding := range httpRule.AdditionalBindings {
+				rule := p.parseHTTPRule(binding)
+				if rule.Method != "" {
+					rule.PathParams = p.ParsePathParams(rule.Pattern)
+					rules = append(rules, rule)
+				}
+			}
+		}
+	}
+
+	return rules
+}
+
+// parseHTTPRule extracts method, pattern, and body from an HttpRule
+func (p *EditionsParser) parseHTTPRule(httpRule *options.HttpRule) HTTPRule {
+	rule := HTTPRule{
+		Body: httpRule.Body,
+	}
+
+	switch pattern := httpRule.Pattern.(type) {
+	case *options.HttpRule_Get:
+		rule.Method = "GET"
+		rule.Pattern = pattern.Get
+	case *options.HttpRule_Post:
+		rule.Method = "POST"
+		rule.Pattern = pattern.Post
+	case *options.HttpRule_Put:
+		rule.Method = "PUT"
+		rule.Pattern = pattern.Put
+	case *options.HttpRule_Delete:
+		rule.Method = "DELETE"
+		rule.Pattern = pattern.Delete
+	case *options.HttpRule_Patch:
+		rule.Method = "PATCH"
+		rule.Pattern = pattern.Patch
+	case *options.HttpRule_Custom:
+		rule.Method = pattern.Custom.Kind
+		rule.Pattern = pattern.Custom.Path
+	}
+
+	rule.PathParams = p.ParsePathParams(rule.Pattern)
+	return rule
+}
+
+// ParsePathParams extracts path parameters from a URL pattern
+func (p *EditionsParser) ParsePathParams(pattern string) []string {
+	params := []string{}
+	re := regexp.MustCompile(`\{([^/{}]+)\}`)
+	matches := re.FindAllStringSubmatch(pattern, -1)
+
+	for _, match := range matches {
+		if len(match) >= 2 {
+			params = append(params, match[1])
+		}
+	}
+
+	return params
+}
+
+// ConvertPathPattern converts a path pattern to Go format
+func (p *EditionsParser) ConvertPathPattern(pattern string) string {
+	// For editions, we just return the pattern as is
+	return pattern
+}

--- a/httpinterface/parser/parser.go
+++ b/httpinterface/parser/parser.go
@@ -1,0 +1,61 @@
+package parser
+
+import (
+	"github.com/golang/protobuf/protoc-gen-go/descriptor"
+)
+
+// HTTPRule represents an HTTP binding from annotations
+type HTTPRule struct {
+	Method     string
+	Pattern    string
+	Body       string
+	PathParams []string
+}
+
+type Parser interface {
+	// ParseHTTPRules extracts HTTP rules from a method descriptor
+	ParseHTTPRules(method *descriptor.MethodDescriptorProto) []HTTPRule
+
+	// ParsePathParams extracts path parameters from a URL pattern
+	ParsePathParams(pattern string) []string
+
+	// ConvertPathPattern converts a path pattern to Go format
+	ConvertPathPattern(pattern string) string
+}
+
+// CreateParser creates a parser appropriate for the given FileDescriptorProto
+func CreateParser(file *descriptor.FileDescriptorProto) Parser {
+	// Check for edition option
+	if hasEditionOption(file) {
+		return NewEditionsParser()
+	}
+
+	// Check syntax field
+	syntax := file.GetSyntax()
+	if syntax == "proto3" {
+		return NewProto3Parser()
+	}
+
+	// Default to proto2
+	return NewProto2Parser()
+}
+
+// hasEditionOption checks if a file has the edition option set
+func hasEditionOption(file *descriptor.FileDescriptorProto) bool {
+	if file.Options == nil {
+		return false
+	}
+
+	// This would need to be implemented to check for the edition option
+	// in the uninterpreted options of the file
+	// Check for edition in uninterpreted options
+	for _, option := range file.Options.UninterpretedOption {
+		for _, name := range option.Name {
+			if name.GetNamePart() == "edition" {
+				return true
+			}
+		}
+	}
+
+	return false
+}

--- a/httpinterface/parser/proto2_parser.go
+++ b/httpinterface/parser/proto2_parser.go
@@ -1,0 +1,98 @@
+package parser
+
+import (
+	"regexp"
+
+	"github.com/golang/protobuf/protoc-gen-go/descriptor"
+	options "google.golang.org/genproto/googleapis/api/annotations"
+	"google.golang.org/protobuf/proto"
+)
+
+// Proto2Parser implements parsing for proto2 files
+type Proto2Parser struct{}
+
+// NewProto2Parser creates a new parser for proto2
+func NewProto2Parser() *Proto2Parser {
+	return &Proto2Parser{}
+}
+
+// ParseHTTPRules extracts HTTP rules from a method descriptor
+func (p *Proto2Parser) ParseHTTPRules(method *descriptor.MethodDescriptorProto) []HTTPRule {
+	rules := []HTTPRule{}
+
+	if method.Options != nil {
+		v := proto.GetExtension(method.Options, options.E_Http)
+		httpRule := v.(*options.HttpRule)
+		if httpRule != nil {
+			// Add the main rule
+			rule := p.parseHTTPRule(httpRule)
+			if rule.Method != "" {
+				rule.PathParams = p.ParsePathParams(rule.Pattern)
+				rules = append(rules, rule)
+			}
+
+			// Add additional bindings
+			for _, binding := range httpRule.AdditionalBindings {
+				rule := p.parseHTTPRule(binding)
+				if rule.Method != "" {
+					rule.PathParams = p.ParsePathParams(rule.Pattern)
+					rules = append(rules, rule)
+				}
+			}
+		}
+	}
+
+	return rules
+}
+
+// parseHTTPRule extracts method, pattern, and body from an HttpRule
+func (p *Proto2Parser) parseHTTPRule(httpRule *options.HttpRule) HTTPRule {
+	rule := HTTPRule{
+		Body: httpRule.Body,
+	}
+
+	switch pattern := httpRule.Pattern.(type) {
+	case *options.HttpRule_Get:
+		rule.Method = "GET"
+		rule.Pattern = pattern.Get
+	case *options.HttpRule_Post:
+		rule.Method = "POST"
+		rule.Pattern = pattern.Post
+	case *options.HttpRule_Put:
+		rule.Method = "PUT"
+		rule.Pattern = pattern.Put
+	case *options.HttpRule_Delete:
+		rule.Method = "DELETE"
+		rule.Pattern = pattern.Delete
+	case *options.HttpRule_Patch:
+		rule.Method = "PATCH"
+		rule.Pattern = pattern.Patch
+	case *options.HttpRule_Custom:
+		rule.Method = pattern.Custom.Kind
+		rule.Pattern = pattern.Custom.Path
+	}
+
+	rule.PathParams = p.ParsePathParams(rule.Pattern)
+	return rule
+}
+
+// ParsePathParams extracts path parameters from a URL pattern
+func (p *Proto2Parser) ParsePathParams(pattern string) []string {
+	params := []string{}
+	re := regexp.MustCompile(`\{([^/{}]+)\}`)
+	matches := re.FindAllStringSubmatch(pattern, -1)
+
+	for _, match := range matches {
+		if len(match) >= 2 {
+			params = append(params, match[1])
+		}
+	}
+
+	return params
+}
+
+// ConvertPathPattern converts a path pattern to Go format
+func (p *Proto2Parser) ConvertPathPattern(pattern string) string {
+	// For proto2, we just return the pattern as is
+	return pattern
+}

--- a/httpinterface/parser/proto3_parser.go
+++ b/httpinterface/parser/proto3_parser.go
@@ -1,0 +1,98 @@
+package parser
+
+import (
+	"regexp"
+
+	"github.com/golang/protobuf/protoc-gen-go/descriptor"
+	options "google.golang.org/genproto/googleapis/api/annotations"
+	"google.golang.org/protobuf/proto"
+)
+
+// Proto3Parser implements parsing for proto3 files
+type Proto3Parser struct{}
+
+// NewProto3Parser creates a new parser for proto3
+func NewProto3Parser() *Proto3Parser {
+	return &Proto3Parser{}
+}
+
+// ParseHTTPRules extracts HTTP rules from a method descriptor
+func (p *Proto3Parser) ParseHTTPRules(method *descriptor.MethodDescriptorProto) []HTTPRule {
+	rules := []HTTPRule{}
+
+	if method.Options != nil {
+		v := proto.GetExtension(method.Options, options.E_Http)
+		httpRule := v.(*options.HttpRule)
+		if httpRule != nil {
+			// Add the main rule
+			rule := p.parseHTTPRule(httpRule)
+			if rule.Method != "" {
+				rule.PathParams = p.ParsePathParams(rule.Pattern)
+				rules = append(rules, rule)
+			}
+
+			// Add additional bindings
+			for _, binding := range httpRule.AdditionalBindings {
+				rule := p.parseHTTPRule(binding)
+				if rule.Method != "" {
+					rule.PathParams = p.ParsePathParams(rule.Pattern)
+					rules = append(rules, rule)
+				}
+			}
+		}
+	}
+
+	return rules
+}
+
+// parseHTTPRule extracts method, pattern, and body from an HttpRule
+func (p *Proto3Parser) parseHTTPRule(httpRule *options.HttpRule) HTTPRule {
+	rule := HTTPRule{
+		Body: httpRule.Body,
+	}
+
+	switch pattern := httpRule.Pattern.(type) {
+	case *options.HttpRule_Get:
+		rule.Method = "GET"
+		rule.Pattern = pattern.Get
+	case *options.HttpRule_Post:
+		rule.Method = "POST"
+		rule.Pattern = pattern.Post
+	case *options.HttpRule_Put:
+		rule.Method = "PUT"
+		rule.Pattern = pattern.Put
+	case *options.HttpRule_Delete:
+		rule.Method = "DELETE"
+		rule.Pattern = pattern.Delete
+	case *options.HttpRule_Patch:
+		rule.Method = "PATCH"
+		rule.Pattern = pattern.Patch
+	case *options.HttpRule_Custom:
+		rule.Method = pattern.Custom.Kind
+		rule.Pattern = pattern.Custom.Path
+	}
+
+	rule.PathParams = p.ParsePathParams(rule.Pattern)
+	return rule
+}
+
+// ParsePathParams extracts path parameters from a URL pattern
+func (p *Proto3Parser) ParsePathParams(pattern string) []string {
+	params := []string{}
+	re := regexp.MustCompile(`\{([^/{}]+)\}`)
+	matches := re.FindAllStringSubmatch(pattern, -1)
+
+	for _, match := range matches {
+		if len(match) >= 2 {
+			params = append(params, match[1])
+		}
+	}
+
+	return params
+}
+
+// ConvertPathPattern converts a path pattern to Go format
+func (p *Proto3Parser) ConvertPathPattern(pattern string) string {
+	// For proto3, we just return the pattern as is
+	return pattern
+}

--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ func main() {
 	flag.Parse()
 
 	if showVersion {
-		fmt.Fprintf(os.Stderr, "protoc-gen-httpinterface 1.0.0\n")
+		fmt.Fprintf(os.Stderr, "protoc-gen-httpinterface 0.0.2\n")
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
This pull request introduces significant updates to the `httpinterface` plugin, focusing on adding support for "editions," improving HTTP rule parsing, and enhancing test coverage. The changes include refactoring the codebase to use a modular parser system, introducing support for editions in the generator, and updating tests to validate the new functionality.

### Editions Support and Generator Enhancements:
* Added a `SupportsEditions` flag to the `Generator` and `Options` structs, allowing the plugin to advertise support for editions, and updated the generator to include this information in the `CodeGeneratorResponse`. (`httpinterface/httpinterface.go` [[1]](diffhunk://#diff-af1b80f5d4b0ef5fa17898e6a8e2bdf1e3022d6cdd0014440912cf83f6601d03R30-R31) [[2]](diffhunk://#diff-af1b80f5d4b0ef5fa17898e6a8e2bdf1e3022d6cdd0014440912cf83f6601d03R70-R110); `httpinterface/options.go` [[3]](diffhunk://#diff-ae5000bf83523cd6e9f6ec867cfdaefedb2619d0dd28c20dbf52789d33b9ea55L14-R15) [[4]](diffhunk://#diff-ae5000bf83523cd6e9f6ec867cfdaefedb2619d0dd28c20dbf52789d33b9ea55R45-R50)
* Modified the generator to set minimum and maximum editions in the response when editions are supported. (`httpinterface/httpinterface.go` [httpinterface/httpinterface.goR70-R110](diffhunk://#diff-af1b80f5d4b0ef5fa17898e6a8e2bdf1e3022d6cdd0014440912cf83f6601d03R70-R110))

### Modular Parser System:
* Introduced a new modular parser system with separate implementations for editions, `proto2`, and `proto3`, allowing the generator to select the appropriate parser based on the file descriptor. (`httpinterface/parser/parser.go` [[1]](diffhunk://#diff-159638078c46ac0e072c74fe37e39cc295b7e7f60df0f97aa569d9abe430cf74R1-R61); `httpinterface/parser/editions_parser.go` [[2]](diffhunk://#diff-21019719dcfed73dce14ec4ca43d650ec1129a062571c882ef64d7894fbeac74R1-R98); `httpinterface/parser/proto2_parser.go` [[3]](diffhunk://#diff-dcddbcc7bf3267288a88dc85ace643b78c1f09f2599dea7b4144a39080bd31afR1-R98)
* Replaced the old HTTP rule extraction logic with a parser-based approach, improving code organization and extensibility. (`httpinterface/annotations.go` [httpinterface/annotations.goL4-R99](diffhunk://#diff-f3aa0460edb9bd2d073bb8ea629a0abcb760ab3e58dd132fe42c66d0c3f83af6L4-R99))

### Critical Fixes and Improvements:
* Ensured that `PathParams` are explicitly populated even when using mocks, addressing potential issues with empty path parameters. (`httpinterface/httpinterface.go` [httpinterface/httpinterface.goL188-R216](diffhunk://#diff-af1b80f5d4b0ef5fa17898e6a8e2bdf1e3022d6cdd0014440912cf83f6601d03L188-R216))
* Updated the `buf.gen.yaml` configuration to support editions in the output options. (`examples/product/buf.gen.yaml` [examples/product/buf.gen.yamlL13-R15](diffhunk://#diff-a057091ae1907f5a33c1bf15bd4135828736866657b20fd19515d0962decd61bL13-R15))

### Test Enhancements:
* Added a new test case, `TestEditionsSupport`, to validate the generator's behavior when editions are enabled, including checking the advertised features and generated output. (`httpinterface/httpinterface_test.go` [httpinterface/httpinterface_test.goR1080-R1184](diffhunk://#diff-acc767b78c577499c360b59bbafa11997924f5ca024bc57c6a8ed7dbd9871a84R1080-R1184))
* Reset parser state in tests to ensure no interference from previous test runs. (`httpinterface/httpinterface_test.go` [httpinterface/httpinterface_test.goR135-R137](diffhunk://#diff-acc767b78c577499c360b59bbafa11997924f5ca024bc57c6a8ed7dbd9871a84R135-R137))

These changes enhance the plugin's flexibility, improve maintainability, and ensure compatibility with evolving protobuf features.